### PR TITLE
[android] --android option gets libicu, NDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ swift.tar.gz
 compiler-rt
 swift-corelibs-libdispatch
 swift-integration-tests
+swift-xcode-playground-support
+libiconv-libicu-android
+
 cache
 .DS_Store
 sysroot

--- a/get.sh
+++ b/get.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+set -e
+set -x
+
 git clone https://github.com/apple/swift.git swift
 ./swift/utils/update-checkout --clone
 ARCH=`arch`
@@ -6,4 +10,13 @@ if [[ $ARCH =~ arm ]]; then
   echo "+ Building for ARM, checkout hpux735 LLVM"
   rm -rf llvm
   git clone --branch arm https://github.com/hpux735/swift-llvm llvm 
+fi
+
+if [[ "$1" == "--android" ]]; then
+  # The Android build depends on libicu.
+  git clone https://github.com/SwiftAndroid/libiconv-libicu-android.git
+  # Download a copy of the latest supported Android NDK.
+  wget http://dl.google.com/android/repository/android-ndk-r12b-linux-x86_64.zip
+  unzip android-ndk-r12b-linux-x86_64.zip
+  rm android-ndk-r12b-linux-x86_64.zip
 fi


### PR DESCRIPTION
Begin adapting the scripts to perform a Swift Android build. The Android build
requires libicu and the Android NDK.
